### PR TITLE
Enforce trailing comma in multiline- arrays and hashes

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -36,7 +36,7 @@ Style/NumericLiterals:
   Enabled: false
 
 Style/TrailingComma:
-  Enabled: false
+  EnforcedStyleForMultiline: comma
 
 Style/AlignParameters:
   EnforcedStyle: with_fixed_indentation


### PR DESCRIPTION
What do you guys think?

See: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
Poll: http://www.poll-maker.com/results276066xC965469d-10?s=res
