### PR TITLE
Increase Metrics/AbcSize

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
 Metrics/LineLength:
   Max: 100
 
+Metrics/AbcSize:
+  Max: 18.11
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
Sometimes Rubocop complains about `Metrics/AbcSize` being too high. In some of these cases I feel like breaking a method up into several ones or doing some code golf only to keep Rubocop from complaining wouldn't actually contribute to improving the code. ([Exhibit A](https://github.com/ad2games/ui_components/blob/6f4e00c36796c7656c6b89e17741818604a3688a/app/cells/select_cell.rb#L18-L26), [Exhibit B](https://github.com/ad2games/ui_components/blob/6f4e00c36796c7656c6b89e17741818604a3688a/app/cells/select_cell.rb#L28-L34)). Can we increase this metric just a little bit... please.
