### PR TITLE
Adds eslint check and small wrapper class.

### DIFF
--- a/config/eslint.json
+++ b/config/eslint.json
@@ -1,0 +1,18 @@
+{
+    "ecmaFeatures": {
+        "jsx": true
+    },
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "globals": {
+        "React": false,
+        "_": false,
+        "$": false
+    },
+    "rules": {
+        "strict": 0,
+        "curly": [2, "multi-line"]
+    }
+}

--- a/lib/eslint.rb
+++ b/lib/eslint.rb
@@ -1,0 +1,39 @@
+require 'mkmf'
+
+class Eslint
+  attr_reader :options
+
+  DEFAULTS = {
+    files: 'app',
+    extensions: %w(.js .jsx),
+  }
+
+  def initialize(options = {})
+    @options = DEFAULTS.merge(options)
+  end
+
+  def executable_exists?
+    executable.present?
+  end
+
+  def executable
+    @executable ||= find_executable('eslint')
+  end
+
+  def pathspec
+    Array.wrap(options[:files]).join(' ')
+  end
+
+  def extensions
+    options[:extensions].map { |e| "--ext #{e}" }.join(' ')
+  end
+
+  def config
+    options.fetch(:config)
+  end
+
+  def run
+    fail('eslint executable could not be found') unless executable_exists?
+    system("#{executable} --config #{config} #{extensions} #{pathspec}") || fail('eslint fail!')
+  end
+end

--- a/lib/tasks/rubocop-ci.rake
+++ b/lib/tasks/rubocop-ci.rake
@@ -7,6 +7,8 @@ require 'coffeelint'
 require 'slim_lint'
 require 'slim_lint/rake_task'
 
+require 'eslint'
+
 rubocop_config = nil
 
 desc 'Runs rubocop with our custom settings'
@@ -28,6 +30,12 @@ RuboCop::RakeTask.new(:rubocop) do |task|
 end
 
 if Dir.exists?('app')
+  task :rubocop do
+    eslint = Eslint.new(config: File.expand_path('../../../config/eslint.json', __FILE__))
+    next eslint.run if eslint.executable_exists?
+    puts 'Warning: the eslint executable could not be found (npm install -g eslint)'
+  end
+
   scss_task = File.exists?("#{Dir.pwd}/.skip_scss_lint") ? :scss_lint : :rubocop
   SCSSLint::RakeTask.new(scss_task) do |task|
     task.config = File.expand_path('../../../config/scss-lint.yml', __FILE__)


### PR DESCRIPTION
Adds `eslint` check for JavaScript and JSX files so we can lint the new React components.

I couldn't find any ruby wrappers aside from [eslint-rails](https://github.com/appfolio/eslint-rails) which was tied to Rails and not very configurable.

It seems easiest to just require that it be installed via `npm` and run the executable directly (rather than trying to run it via `ExecJS`).  `npm` is already installed on CircleCI so it shouldn't be an issue.  The task emits a warning if the executable isn't found.
