### PR TITLE
Allow 'has_' prefix for predicate method names

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -33,6 +33,11 @@ Style/ClassAndModuleChildren:
 Style/MultilineBlockChain:
   Enabled: false
 
+Style/PredicateName:
+  NamePrefixBlacklist:
+    - is_
+    - have_
+
 Rails/HasAndBelongsToMany:
   Enabled: false
 


### PR DESCRIPTION
For example, Rails has a bunch of predicates starting with `has_` (e.g. `http://api.rubyonrails.org/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-has_named_route-3F`). So I think, we can use it also, if it helps the code to read more meaningful.
