### PR TITLE
Update the rubocop gem

### DIFF
--- a/lib/tasks/rubocop-ci.rake
+++ b/lib/tasks/rubocop-ci.rake
@@ -45,7 +45,7 @@ if Dir.exist?('app')
   task :rubocop do
     config = File.expand_path('../../../config/coffeelint.json', __FILE__)
     failures = Coffeelint.run_test_suite('app', config_file: config)
-    fail('Coffeelint fail!') if failures > 0
+    raise('Coffeelint fail!') if failures > 0
   end
 
   SlimLint::RakeTask.new(:rubocop) do |task|
@@ -56,7 +56,7 @@ if Dir.exist?('app')
   task :rubocop do
     install = 'npm install standard -g'
     sh install if ENV['CI']
-    fail "Please install standard: #{install}" unless system('which standard')
+    raise "Please install standard: #{install}" unless system('which standard')
 
     sh 'standard'
   end
@@ -70,7 +70,7 @@ if Dir.exist?('app')
       puts 'Brakeman OK'
     else
       puts result.report.to_s
-      fail 'Brakeman Errors'
+      raise 'Brakeman Errors'
     end
   end
 end

--- a/rubocop-ci.gemspec
+++ b/rubocop-ci.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license     = ''
 
   s.add_dependency 'rake'
-  s.add_dependency 'rubocop', '~> 0.36.0'
+  s.add_dependency 'rubocop', '~> 0.37.0'
   s.add_dependency 'rubocop-rspec'
   s.add_dependency 'scss_lint'
   s.add_dependency 'coffeelint'


### PR DESCRIPTION
Now it adds a `# frozen_string_literal: true` comment to the top of the files where strings literals are used. So you don't need to explicitly freeze strings.
See https://github.com/bbatsov/rubocop/releases/tag/v0.37.0
