### PR TITLE
Two empty lines sometimes very useful. It would not be good to prevent them blindly.

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -89,3 +89,6 @@ Rails/FindBy:
 
 Rails/FindEach:
   Include: null
+
+Style/EmptyLines:
+  Enabled: false


### PR DESCRIPTION
For example:
- constants in classes and modules
- separating attributes in classes and modules
- let statements in specs
