### PR TITLE
Enable Rails/Date Rails/Timezone rules

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -47,10 +47,10 @@ Rails/HasAndBelongsToMany:
   Enabled: false
 
 Rails/TimeZone:
-  Enabled: false
+  EnforcedStyle: flexible
 
 Rails/Date:
-  Enabled: false
+  EnforcedStyle: flexible
 
 RSpec/DescribeClass:
   Enabled: false


### PR DESCRIPTION
Because my system is in UTC-3 I had lot of failing tests in dhw-service and
backoffice, due to usage of "dangerous" methods that don't know anything
about Rails time zone.

See also https://github.com/ad2games/dwh-service/pull/314
