### PR TITLE
Disable Style/IndentHash rubocop lint for slim-lint

### DIFF
--- a/config/slim-lint.yml
+++ b/config/slim-lint.yml
@@ -4,3 +4,26 @@ linters:
     exclude:
       # Mail templates tend to be a huge mess of HTML - so we disable the line length restriction
       - 'app/views/layouts/mailer.html.slim'
+
+  RuboCop:
+    # TODO: Remove (and let defaults apply) once https://github.com/sds/slim-lint/issues/30 is fixed
+    ignored_cops:
+      - Style/IndentHash
+      # defaults from slim-lint:
+      - Lint/BlockAlignment
+      - Lint/EndAlignment
+      - Lint/Void
+      - Metrics/LineLength
+      - Style/AlignHash
+      - Style/AlignParameters
+      - Style/BlockNesting
+      - Style/FileName
+      - Style/FirstParameterIndentation
+      - Style/FrozenStringLiteralComment
+      - Style/IfUnlessModifier
+      - Style/IndentationConsistency
+      - Style/IndentationWidth
+      - Style/Next
+      - Style/TrailingBlankLines
+      - Style/TrailingWhitespace
+      - Style/WhileUntilModifier


### PR DESCRIPTION
Ruby code extracted from Slim templates isn't formatted up to Rubocop's standards.
See https://github.com/sds/slim-lint/issues/30 for the problem description.

slim-lint only allows to override the whole list, not extend it, so this change includes
the default list plus `Style/IndentHash`.

Default config for reference https://github.com/sds/slim-lint/blob/master/config/default.yml
