### PR TITLE
Run standard over correct JavaScript directory.

### DIFF
--- a/lib/tasks/rubocop-ci.rake
+++ b/lib/tasks/rubocop-ci.rake
@@ -59,7 +59,7 @@ if Dir.exist?('app')
     sh install if ENV['CI']
     raise "Please install standard: #{install}" unless system('which standard')
 
-    sh 'standard --parser babel-eslint app/assets/javascript/**/*.js? client/{app,lib}/**/*.js?'
+    sh 'standard --parser babel-eslint app/assets/javascripts/**/*.js? client/{app,lib}/**/*.js?'
   end
 
   task :rubocop do


### PR DESCRIPTION
Change `app/assets/javascript` -> `app/assets/javascripts` to ensure standard babel-eslint runs over all JS files
