### PR TITLE
Use `strict` for Rails/Date and Rails/TimeZone

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -47,10 +47,10 @@ Rails/HasAndBelongsToMany:
   Enabled: false
 
 Rails/TimeZone:
-  EnforcedStyle: flexible
+  EnforcedStyle: strict
 
 Rails/Date:
-  EnforcedStyle: flexible
+  EnforcedStyle: strict
 
 RSpec/DescribeClass:
   Enabled: false


### PR DESCRIPTION
Instead of using the `flexible` settings, how about using `strict` for the [Rails/Date](https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L1203) and [Rails/TimeZone](https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L1266) cops? It's more explicit. That's all.

What do you think?
