### PR TITLE
Fix error with babel ES linter

### DIFF
--- a/lib/tasks/rubocop-ci.rake
+++ b/lib/tasks/rubocop-ci.rake
@@ -59,7 +59,8 @@ if Dir.exist?('app')
     sh install if ENV['CI']
     raise "Please install standard: #{install}" unless system('which standard')
 
-    sh 'standard --parser babel-eslint app/assets/javascripts/**/*.js? client/{app,lib}/**/*.js?'
+    files = Dir['{app/assets/javascripts,client/app,client/lib}/**/*.{js,jsx}'].join(' ')
+    sh "standard --parser babel-eslint #{files}"
   end
 
   task :rubocop do


### PR DESCRIPTION
Original version was not linting any jsx files in the second directory if no files were found in the first listed directory.
