### PR TITLE
Disable Rails/HttpPositionalArguments

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -114,3 +114,8 @@ Rails/FindBy:
 
 Rails/FindEach:
   Include: null
+
+# Disabled since it only applies to Rails 5. Reenable when we migrate our apps to Rails 5.
+# https://github.com/bbatsov/rubocop/issues/3629
+Rails/HttpPositionalArguments:
+  Enabled: false


### PR DESCRIPTION
While our apps are still on Rails 4.2, because this rule only applies to Rails 5
https://github.com/bbatsov/rubocop/issues/3629