### PR TITLE
Ignore node_modules directory

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'vendor/**/*'
     - 'client/**/*'
     - 'spec/dummy/db/schema.rb'
+    - '**/node_modules/**/*'
 
 Metrics/LineLength:
   Max: 100


### PR DESCRIPTION
The current default location of the `node_modules` directory is in the root of the project. Let's just ignore it wherever it is, though.