### PR TITLE
Fix slim-lint config

### DIFF
--- a/config/slim-lint.yml
+++ b/config/slim-lint.yml
@@ -3,7 +3,7 @@ linters:
     max: 100
     exclude:
       # Mail templates tend to be a huge mess of HTML - so we disable the line length restriction
-      - 'app/views/layouts/mailer.html.slim'
+      - '**/app/views/layouts/mailer.html.slim'
   ConsecutiveControlStatements:
     enabled: false
 


### PR DESCRIPTION
After this change https://github.com/sds/slim-lint/commit/ef9a07f5c063bf7d766e770483b1f49c44d4bc87
slim-lint fails to handle relative paths in the "exclude" setting for specific linters.

A workaround I found is to use a glob, by prepending `**/` to the path.