### PR TITLE
Update rubocop

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -29,6 +29,11 @@ Style/AsciiComments:
 Style/Documentation:
   Enabled: false
 
+# Enable the cop after it has learned to distinguish strftime.
+# See https://github.com/bbatsov/rubocop/issues/5398
+Style/FormatStringToken:
+  Enabled: false
+
 Style/IfUnlessModifier:
   Enabled: false
 
@@ -57,6 +62,9 @@ Naming/PredicateName:
   NamePrefixBlacklist:
     - is_
     - have_
+
+Rails/CreateTableWithTimestamps:
+  Enabled: false
 
 Rails/HasAndBelongsToMany:
   Enabled: false
@@ -117,6 +125,9 @@ Style/Send:
 
 Style/StringMethods:
   Enabled: true
+
+Rails/RedundantReceiverInWithOptions:
+  Enabled: false
 
 Rails/SaveBang:
   Enabled: true

--- a/lib/rubocop-ci.rb
+++ b/lib/rubocop-ci.rb
@@ -12,3 +12,4 @@ if defined?(Rails)
 else
   load 'tasks/rubocop-ci.rake'
 end
+# rubocop:enable Naming/FileName

--- a/rubocop-ci.gemspec
+++ b/rubocop-ci.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'coffeelint', '~> 1.16.0'
   s.add_dependency 'rake'
-  s.add_dependency 'rubocop', '~> 0.51.0'
+  s.add_dependency 'rubocop', '~> 0.52.0'
   s.add_dependency 'rubocop-rspec', '= 1.19.0' # hard lock, they break semver promises
   s.add_dependency 'scss_lint', '~> 0.56.0'
   s.add_dependency 'slim_lint', '~> 0.15.0'


### PR DESCRIPTION
It's happening again 😄 
We need the new version to be able to update to ruby 2.5.
Though, likely the only hassle with this update is adding `inverse_of` to the AR associations.