### PR TITLE
Enable MethodLength cop for migrations

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -19,10 +19,6 @@ Metrics/BlockLength:
     - '*.gemspec'
     - 'config/routes.rb'
 
-Metrics/MethodLength:
-  Exclude:
-    - 'db/migrate/*.rb'
-
 Style/AsciiComments:
   Enabled: false
 


### PR DESCRIPTION
Based on the discussion in https://github.com/ad2games/rubocop-ci/pull/33.