### PR TITLE
Remove target ruby version from Rubocop config

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.3
   Exclude:
     - '**/*.pb.rb'
     - '**/*_pb.rb'


### PR DESCRIPTION
[Rubocop is `.ruby-version`-aware.](https://rubocop.readthedocs.io/en/latest/configuration/#setting-the-target-ruby-version)