### PR TITLE
Remove version lock for babel-eslint

### DIFF
--- a/lib/tasks/rubocop-ci.rake
+++ b/lib/tasks/rubocop-ci.rake
@@ -17,9 +17,7 @@ def config_file(name)
 end
 
 def check_standard
-  # Remove babel-eslint version lock after the issue has been resolved:
-  # https://github.com/standard/standard/issues/1035
-  install = 'npm install standard babel-eslint@8.0.3 -g'
+  install = 'npm install standard babel-eslint -g'
   sh install if ENV['CI']
   raise "Please install standard: #{install}" unless system('which standard')
 end


### PR DESCRIPTION
Now it fails with the locked version, but works with the newer one