### PR TITLE
Consider inherted class when checking uniqueness

### DIFF
--- a/exe/clockwork-lint
+++ b/exe/clockwork-lint
@@ -30,6 +30,8 @@ class WorkersWithUniquenessList
     walk(RuboCop::ProcessedSource.from_file(file_path, ruby_version).ast)
   end
 
+  private
+
   def on_send(node)
     return unless node.command?(:sidekiq_options)
     node.arguments[0].each_pair do |key, value|
@@ -40,17 +42,77 @@ class WorkersWithUniquenessList
   end
 end
 
-clockwork_config_file = 'config/clockwork.rb'
-exit unless File.exist?(clockwork_config_file)
+class WorkersAncestors
+  include RuboCop::AST::Traversal
+  attr_reader :ancestors
 
-config_store = RuboCop::ConfigStore.new
-workers = ClockworkWorkersList.new(config_store, clockwork_config_file).workers
-workers_with_uniqueness = Dir['app/workers/**/*_worker.rb']
-  .each_with_object(Set.new) do |worker_path, acc|
-    acc.merge WorkersWithUniquenessList.new(worker_path, config_store).workers
+  def initialize(file_path, config_store)
+    @ancestors = {}
+    ruby_version = config_store.for(file_path).target_ruby_version
+    walk(RuboCop::ProcessedSource.from_file(file_path, ruby_version).ast)
   end
 
-if (workers_wo_uniqueness = workers - workers_with_uniqueness).any?
+  private
+
+  def on_class(node)
+    _class, parent_class, _body = *node
+    return unless parent_class
+
+    # For now, assume the inherited class is in the same namespace.
+    ancestors["#{node.parent_module_name}::#{node.defined_module_name}"] =
+      "#{node.parent_module_name}::#{parent_class.const_name}"
+  end
+end
+
+class WorkersWithoutUniquenessList
+  def initialize(config_store, clockwork_config_file)
+    @config_store = config_store
+    @clockwork_config_file = clockwork_config_file
+  end
+
+  def workers
+    workers_wo_uniqueness
+  end
+
+  private
+
+  attr_reader :config_store, :clockwork_config_file
+
+  def workers_wo_uniqueness
+    (clockwork_workers - workers_with_uniqueness).reject do |worker_wo_uniqueness|
+      workers_with_uniqueness.include?(ancestors[worker_wo_uniqueness])
+    end
+  end
+
+  def ancestors
+    @ancestors ||= worker_paths.reduce({}) do |ancestors, path|
+      ancestors.merge(WorkersAncestors.new(path, config_store).ancestors)
+    end
+  end
+
+  def workers_with_uniqueness
+    @workers_with_uniqueness ||= worker_paths.reduce(Set.new) do |workers, path|
+      workers.merge(WorkersWithUniquenessList.new(path, config_store).workers)
+    end
+  end
+
+  def worker_paths
+    @worker_paths ||= Dir['app/workers/**/*_worker.rb']
+  end
+
+  def clockwork_workers
+    ClockworkWorkersList.new(config_store, clockwork_config_file).workers
+  end
+end
+
+clockwork_config_file = 'config/clockwork.rb'
+exit unless File.exist?(clockwork_config_file)
+config_store = RuboCop::ConfigStore.new
+workers_wo_uniqueness = WorkersWithoutUniquenessList
+  .new(config_store, clockwork_config_file)
+  .workers
+
+if workers_wo_uniqueness.any?
   STDERR.puts 'Following workers are called by the Clockwork, but are missing a uniqueness setting.'
   STDERR.puts 'To avoid having duplicate jobs, please, ' \
     'pass `unique: :until_executed` to the `sidekiq_options` call.'


### PR DESCRIPTION
`clockwork-lint` used to complain about workers not having the unique
setting set, even if they inherit from a class that does. No more!