### PR TITLE
Update some dependencies.

### DIFF
--- a/config/slim-lint.yml
+++ b/config/slim-lint.yml
@@ -7,6 +7,9 @@ linters:
   ConsecutiveControlStatements:
     enabled: false
 
+  ControlStatementSpacing:
+    enabled: false
+
   RuboCop:
     # TODO: Remove (and let defaults apply) once https://github.com/sds/slim-lint/issues/30 is fixed
     ignored_cops:

--- a/rubocop-ci.gemspec
+++ b/rubocop-ci.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'rubocop-ci'
-  s.version     = '1.0.1'
+  s.version     = '1.0.2'
   s.date        = '2015-03-17'
   s.summary     = 'Runs rubocop with our settings'
   s.description = ''
@@ -20,11 +20,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake'
   s.add_dependency 'rubocop', '~> 0.52.0'
   s.add_dependency 'rubocop-rspec', '= 1.19.0' # hard lock, they break semver promises
-  s.add_dependency 'scss_lint', '~> 0.56.0'
-  s.add_dependency 'slim_lint', '~> 0.15.0'
+  s.add_dependency 'scss_lint', '~> 0.57.0'
+  s.add_dependency 'slim_lint', '~> 0.16.1'
 
   # Use brakeman with less dependencies, but still have nice output
-  s.add_dependency 'brakeman-min', '~> 4.0.1'
+  s.add_dependency 'brakeman-min', '~> 4.3.1'
   s.add_dependency 'highline'
   s.add_dependency 'terminal-table'
 end


### PR DESCRIPTION
Mostly because the old version of slim_lint didn't allow the use of slim 4.

I disabled [ControlStatementSpacing](https://github.com/sds/slim-lint/blob/master/lib/slim_lint/linter/README.md#controlstatementspacing) because we mostly use `div= code` over `div = code` style