### PR TITLE
Use standalone Brakeman

### DIFF
--- a/lib/tasks/rubocop-ci.rake
+++ b/lib/tasks/rubocop-ci.rake
@@ -8,7 +8,6 @@ require 'scss_lint/rake_task'
 require 'coffeelint'
 require 'slim_lint'
 require 'slim_lint/rake_task'
-require 'brakeman'
 
 rubocop_config = nil
 
@@ -90,16 +89,8 @@ if Dir.exist?('app')
   end
 
   task :rubocop do
-    result = Brakeman.run(app_path: '.', exit_on_warn: true)
-    ignored = result.ignored_filter&.ignored_warnings || []
-    errors = result.errors + result.warnings - ignored
-
-    if errors.empty?
-      puts 'Brakeman OK'
-    else
-      puts result.report.to_s
-      raise 'Brakeman Errors'
-    end
+    success = system('bundle exec brakeman --no-pager')
+    raise 'Brakeman Errors' unless success
   end
 
   task :rubocop do


### PR DESCRIPTION
Brakeman's dependencies conflict with the project's dependencies and it
is [recommended](https://github.com/presidentbeef/brakeman/issues/1044) to not use it with Rake.

Specifically, it had an issue with HAML 5, which I had to update to, in order to be able to update to Rails 5.2.