### PR TITLE
Add missing eslint to Rake task

### DIFF
--- a/lib/tasks/rubocop-ci.rake
+++ b/lib/tasks/rubocop-ci.rake
@@ -17,7 +17,7 @@ end
 
 def check_standard
   # Unlock standard when https://github.com/standard/standard/issues/1328 gets resolved.
-  install = "npm install 'standard@<13' babel-eslint -g"
+  install = "npm install 'standard@<13' babel-eslint eslint -g"
   sh install if ENV['CI']
   raise "Please install standard: #{install}" unless system('which standard')
 end


### PR DESCRIPTION
This should fix standard failing with "Cannot find module 'eslint'" and
> npm WARN babel-eslint@10.0.3 requires a peer of eslint@>= 4.12.1 but none is installed. You must install peer dependencies yourself.