### PR TITLE
Remove rubocop-faker

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -1,7 +1,6 @@
 require:
   - rubocop-performance
   - rubocop-rails
-  - rubocop-faker
 AllCops:
   Exclude:
     - '**/*.pb.rb'

--- a/rubocop-ci.gemspec
+++ b/rubocop-ci.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffeelint', '~> 1.16.0'
   s.add_dependency 'rake'
   s.add_dependency 'rubocop', '~> 0.74'
-  s.add_dependency 'rubocop-faker'
   s.add_dependency 'rubocop-performance'
   s.add_dependency 'rubocop-rails', '~> 2.5.2'
   s.add_dependency 'rubocop-rspec', '= 1.19.0' # hard lock, they break semver promises


### PR DESCRIPTION
It seems to be only helpful as a one-off migration tool. Let's remove it.