### PR TITLE
Add rubocop-git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ jobs:
 
       - run:
           name: Run rubocop
-          command: bundle exec rake rubocop
+          command: bundle exec rake rubocop_ci:rubocop
 
       - run:
           name: Run rubocop on changes in the branch only
-          command: bundle exec rake rubocop:diff
+          command: bundle exec rake rubocop_ci:rubocop:diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,5 +35,5 @@ jobs:
           command: bundle exec rake rubocop
 
       - run:
-          name: Run rubocop-git
-          command: bundle exec rake rubocop_git
+          name: Run rubocop on changes in the branch only
+          command: bundle exec rake rubocop_diff

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,3 +33,7 @@ jobs:
       - run:
           name: Run rubocop
           command: bundle exec rake rubocop
+
+      - run:
+          name: Run rubocop-git
+          command: bundle exec rake rubocop_git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,4 +36,4 @@ jobs:
 
       - run:
           name: Run rubocop on changes in the branch only
-          command: bundle exec rake rubocop_diff
+          command: bundle exec rake rubocop:diff

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Please double check the results before committing!
 If your project needs relaxed settings, you can generate a `.rubocop_todo.yml`
 file using `bundle exec rake rubocop AUTOGEN=1`.
 
+Alternatively, there is a `rubocop:diff` Rake task that runs Rubocop only on
+the changes in your branch. This helps if you want to keep Rubocop up-to-date
+but don't want to change your whole code-base every time there is an update and
+also don't want to mask global settings in a `.rubocop_todo.yml`.
+
 If you do not want to run `scss-lint` on your project (yet),
 you can create a `.skip_scss_lint` file in your project root.
 

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - 'client/**/*'
     - 'spec/dummy/db/schema.rb'
     - '**/node_modules/**/*'
+  NewCops: enable
 
 Metrics/AbcSize:
   Exclude:

--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -102,7 +102,7 @@ desc 'Runs rubocop-git with our custom settings'
 task :rubocop_diff do |_task|
   require 'rubocop/git/cli'
   config = generate_rubocop_config(todo: false)
-  options = ['-D', '-c', config]
+  options = ['-D', '-c', config, 'origin/master...']
   logger.info("rubocop-git #{options.join(' ')}")
   RuboCop::Git::CLI.new.run(options)
 end

--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -92,7 +92,7 @@ RuboCop::RakeTask.new(:rubocop) do |task|
 end
 
 desc 'Runs rubocop-git with our custom settings'
-task :rubocop_git do |_task|
+task :rubocop_diff do |_task|
   require 'rubocop/git/cli'
   config = generate_rubocop_config(todo: false)
   options = ['-D', '-c', config]

--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -84,18 +84,24 @@ def include_todo_config(config_files)
 end
 
 desc 'DEPRECATED: Run all linters'
-task rubocop: [
-  :'rubocop_ci:rubocop',
-  (:'rubocop_ci:scss_lint' unless File.exist?("#{Dir.pwd}/.skip_scss_lint")),
-  :'rubocop_ci:slim_lint',
-  :'rubocop_ci:coffee_lint',
-  :'rubocop_ci:javascript_lint',
-  :'rubocop_ci:brakeman',
-  :'rubocop_ci:i18n_lint',
-  :'rubocop_ci:clockwork_lint'
-].compact
+# TODO: Delete on next major release
+task rubocop: %i[rubocop_ci:rubocop] +
+  if Dir.exist?('app')
+    [
+      (:'rubocop_ci:scss_lint' unless File.exist?("#{Dir.pwd}/.skip_scss_lint")),
+      :'rubocop_ci:slim_lint',
+      :'rubocop_ci:coffee_lint',
+      :'rubocop_ci:javascript_lint',
+      :'rubocop_ci:brakeman',
+      :'rubocop_ci:i18n_lint',
+      :'rubocop_ci:clockwork_lint'
+    ].compact
+  else
+    []
+  end
 
 desc 'DEPRECATED: Run linters that are auto-correct capable'
+# TODO: Delete on next major release
 namespace :rubocop do
   task auto_correct: :'rubcocop_ci:auto_correct'
 end

--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -91,6 +91,7 @@ RuboCop::RakeTask.new(:rubocop) do |task|
   logger.info("rubocop #{task.options.join(' ')}")
 end
 
+desc 'Runs rubocop-git with our custom settings'
 task :rubocop_git do |_task|
   require 'rubocop/git/cli'
   options = ['-D', '-c', rubocop_config]

--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -99,12 +99,14 @@ RuboCop::RakeTask.new(:rubocop) do |task|
 end
 
 desc 'Runs rubocop-git with our custom settings'
-task :rubocop_diff do |_task|
-  require 'rubocop/git/cli'
-  config = generate_rubocop_config(todo: false)
-  options = ['-D', '-c', config, 'origin/master...']
-  logger.info("rubocop-git #{options.join(' ')}")
-  RuboCop::Git::CLI.new.run(options)
+namespace :rubocop do
+  task :diff do
+    require 'rubocop/git/cli'
+    config = generate_rubocop_config(todo: false)
+    options = ['-D', '-c', config, 'origin/master...']
+    logger.info("rubocop-git #{options.join(' ')}")
+    RuboCop::Git::CLI.new.run(options)
+  end
 end
 
 if Dir.exist?('app')

--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -119,10 +119,11 @@ namespace :rubocop_ci do # rubocop:disable Metrics/BlockLength
 
   desc 'Runs rubocop-git with our custom settings'
   namespace :rubocop do
-    task :diff do
+    task :diff, %i[reference_branch] do |_task, args|
       require 'rubocop/git/cli'
       config = generate_rubocop_config(todo: false)
-      options = ['-D', '-c', config, 'origin/master...']
+      reference_branch = args[:reference_branch] || 'origin/master...'
+      options = ['-D', '-c', config, reference_branch]
       logger.info("rubocop-git #{options.join(' ')}")
       RuboCop::Git::CLI.new.run(options)
     end

--- a/rubocop-ci.gemspec
+++ b/rubocop-ci.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'coffeelint', '~> 1.16.0'
   s.add_dependency 'rake'
-  s.add_dependency 'rubocop', '= 0.83'
+  s.add_dependency 'rubocop', '~> 0.83.0'
+  s.add_dependency 'rubocop-git'
   s.add_dependency 'rubocop-performance'
   s.add_dependency 'rubocop-rails', '~> 2.5.2'
   s.add_dependency 'rubocop-rspec', '= 1.19.0' # hard lock, they break semver promises

--- a/rubocop-ci.gemspec
+++ b/rubocop-ci.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |s|
   s.license     = ''
 
   s.add_dependency 'coffeelint', '~> 1.16.0'
+  s.add_dependency 'cs-rubocop-git'
   s.add_dependency 'rake'
   s.add_dependency 'rubocop', '~> 0.83.0'
-  s.add_dependency 'cs-rubocop-git'
   s.add_dependency 'rubocop-performance'
   s.add_dependency 'rubocop-rails', '~> 2.5.2'
   s.add_dependency 'rubocop-rspec', '= 1.19.0' # hard lock, they break semver promises

--- a/rubocop-ci.gemspec
+++ b/rubocop-ci.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coffeelint', '~> 1.16.0'
   s.add_dependency 'rake'
   s.add_dependency 'rubocop', '~> 0.83.0'
-  s.add_dependency 'rubocop-git'
+  s.add_dependency 'cs-rubocop-git'
   s.add_dependency 'rubocop-performance'
   s.add_dependency 'rubocop-rails', '~> 2.5.2'
   s.add_dependency 'rubocop-rspec', '= 1.19.0' # hard lock, they break semver promises


### PR DESCRIPTION
This adds a task to run Rubocop only on the changes in the current branch, skipping the TODO file. This helps to prevent introducing new issues Rubocop would normally complain about, that are masked by a global setting in the TODO file.