### PR TITLE
Keep tempfile references in global variable

### DIFF
--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -56,10 +56,16 @@ def generate_rubocop_config(todo:)
   config_files = include_rails_config(config_files)
   config_files = include_todo_config(config_files) if todo
 
-  rubocop_config = Tempfile.new('rubocop')
+  rubocop_config = new_tempfile
   rubocop_config.write(YAML.dump('inherit_from' => config_files))
   rubocop_config.close
   rubocop_config.path
+end
+
+def new_tempfile
+  $tempfiles ||= []
+  $tempfiles << Tempfile.new('rubocop')
+  $tempfiles.last
 end
 
 def include_rails_config(config_files)

--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -63,9 +63,9 @@ def generate_rubocop_config(todo:)
 end
 
 def new_tempfile
-  $tempfiles ||= []
-  $tempfiles << Tempfile.new('rubocop')
-  $tempfiles.last
+  @tempfiles ||= []
+  @tempfiles << Tempfile.new('rubocop')
+  @tempfiles.last
 end
 
 def include_rails_config(config_files)


### PR DESCRIPTION
Tempfiles are deleted when their references are garbage-collected, which
can happen as soon as the function they are created in ends. By keeping
the reference in a ~~global~~ instance variable, we make sure it exists until the end
of the script.