### PR TITLE
Pin eslint to <8

### DIFF
--- a/lib/tasks/rubocop_ci.rake
+++ b/lib/tasks/rubocop_ci.rake
@@ -25,7 +25,7 @@ end
 
 def check_standard
   # Unlock standard when https://github.com/standard/standard/issues/1328 gets resolved.
-  install = "npm install 'standard@<13' babel-eslint eslint -g"
+  install = "npm install 'standard@<13' babel-eslint 'eslint@<8' -g"
   sh install if ENV['CI']
   raise "Please install standard: #{install}" unless system('which standard')
 end


### PR DESCRIPTION
This keeps `standard` operational.